### PR TITLE
feat/[부루트포스 2003 수들의 합 2] 풀이 추가

### DIFF
--- a/src/com/lk/study/baekjoon/_2003/kim/Main.java
+++ b/src/com/lk/study/baekjoon/_2003/kim/Main.java
@@ -1,0 +1,45 @@
+package com.lk.study.baekjoon._2003.kim;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * <h3>브루트포스 > 2003 수들의 합 2</h3>
+ * <pre>
+ * 레벨 - 실버4
+ * 시간 - 23.02.14 20:32 ~ 21:10(38분 목표 / 21:05 33분 성공)
+ * </pre>
+ */
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        var br = new BufferedReader(new InputStreamReader(System.in));
+        var arr = br.readLine().split(" ");
+        var N = Integer.parseInt(arr[0]);
+        var M = Integer.parseInt(arr[1]);
+        var A = br.readLine().split(" ");
+
+        var self = new Main();
+        System.out.println(self.getSumNumberCount(A, N, M));
+    }
+
+    private int getSumNumberCount(String[] A, int N, int M) {
+        var sumCount = 0;
+        for (int i = 0; i < N; i++) {
+            var sum = 0;
+            for (int j = i; j < N; j++) {
+                sum += Integer.parseInt(A[j]);
+                if (sum == M) {
+                    sumCount++;
+                    break;
+                } else if (sum > M) {
+                    break;
+                }
+            }
+        }
+
+        return sumCount;
+    }
+
+}


### PR DESCRIPTION
## PR 설명
|알고리즘|번호|이름|레벨|성공여부|
|---|---|---|---|---|
| 부루트포스 | 2003 | 수들의 합 2 | 실버4 | 성공 |

## 상세 설명
- 3중 포문 사용하여 시간초과 발생
- 이후 시작 위치에서 더하며 진행하는 누산기 방식으로 변경하여 성공함(2중 포문으로 변경)

## 문제 링크
- [백준 2003 수들의 합 2 문제보기](https://www.acmicpc.net/problem/2003)